### PR TITLE
feature: made the cookies httpOnly

### DIFF
--- a/src/utils/supabase/server.ts
+++ b/src/utils/supabase/server.ts
@@ -1,5 +1,5 @@
-import {createServerClient} from '@supabase/ssr';
-import {cookies} from 'next/headers';
+import { createServerClient } from '@supabase/ssr';
+import { cookies } from 'next/headers';
 
 export async function createClient() {
   const cookieStore = await cookies();
@@ -14,10 +14,11 @@ export async function createClient() {
         },
         setAll(cookiesToSet) {
           try {
-            cookiesToSet.forEach(({name, value, options}) =>
+            cookiesToSet.forEach(({ name, value, options }) =>
               cookieStore.set(name, value, {
                 ...options,
                 secure: process.env.NODE_ENV === 'production',
+                httpOnly: true,
               })
             );
           } catch {


### PR DESCRIPTION
Closes #53 

# Changes

1. Middleware alterates the cookies to be httpOnly

## Additional Notes

We are not using drectly the supabase functions on client so we can block the access to the authentication cookies via scripts
